### PR TITLE
Добавить в нотификатор работу через блок

### DIFF
--- a/lib/owl/logger_with_notifications.rb
+++ b/lib/owl/logger_with_notifications.rb
@@ -5,27 +5,40 @@ class LoggerWithNotifications < Logger
   end
 
   def warn(progname = nil, &block)
-    notify(progname, title: 'Warning')
+    notify(progname, title: 'Warning', &block)
     super(progname, &block)
   end
 
   def error(progname = nil, &block)
-    notify(progname, title: 'Error')
+    notify(progname, title: 'Error', &block)
     super(progname, &block)
   end
 
   def fatal(progname = nil, &block)
-    notify(progname, title: 'Warning')
+    notify(progname, title: 'Warning', &block)
     super(progname, &block)
   end
 
   def info(progname = nil, silent = true, &block)
-    notify(progname, title: 'Info') unless silent
+    notify(progname, title: 'Info', &block) unless silent
     super(progname, &block)
   end
 
   private
-    def notify(message, title: '')
-      @notifier.ping("*#{title}*", attachments: [{ text: message.kind_of?(Exception) ? "*#{message.inspect}* ```#{message.backtrace.join("\n").gsub("`", "'")}```" : message.to_s, mrkdwn_in: %w(text) }])
-    end
+
+  def notify(message, title: '')
+    message =
+      if block_given?
+        yield
+      elsif message.kind_of?(Exception)
+        "*#{message.inspect}* ```#{message.backtrace.join("\n").gsub("`", "'")}```"
+      else
+        message.to_s
+      end
+
+    @notifier.ping(
+      "*#{title}*",
+      attachments: [{ text: message, mrkdwn_in: %w[text] }]
+    )
+  end
 end


### PR DESCRIPTION
ActiveJob прокидывает ошибки через блок, так что теперь логгер с нотификациями можно внедрить в него.
